### PR TITLE
Add a warning to cookie clicker

### DIFF
--- a/p/cookieclicker.html
+++ b/p/cookieclicker.html
@@ -48,7 +48,8 @@
                 if you want to play this on an iPad (safari), tap on the "aA" button on the top left of your screen, on
                 the
                 left
-                side of the url box, then tap on "Request Mobile Site"
+                side of the url box, then tap on "Request Mobile Site"<br>
+                This game might not work since it has new protections that restrict Cookie Clicker from being played on anywhere other than the official Cookie Clicker website.
             </div> <br>
             <div id="wgEmbed">
                 <iframe src="../games/html5/cookieclicker" >


### PR DESCRIPTION
#141 - Cookie Clicker is broken
https://mathgames69.github.io/p/cookieclicker.html (Proxy since mg66 is blocked on my internet)
Mathgames66 is not a whitelisted Cookie Clicker URL, so this adds a warning to Cookie Clicker.

Also whoever merges this - are you able to add me as a member of this repo so I can work on it? The school is taking me to court so now I'm revolting against them.